### PR TITLE
Improved redirection support

### DIFF
--- a/plugins/quant/quant.php
+++ b/plugins/quant/quant.php
@@ -5,7 +5,7 @@
  * Description: QuantCDN static edge integration
  * Author: Stuart Rowlands
  * Plugin URI: https://www.quantcdn.io
- * Version: 1.4.1
+ * Version: 1.4.2
  * License: GPL-2.0+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  */
@@ -16,6 +16,10 @@ if (!defined('ABSPATH')) {
 
 require_once(__DIR__.'/src/App.php');
 require_once(__DIR__.'/wp-batch-processing/wp-batch-processing.php');
+
+if (!function_exists('is_plugin_active')) {
+  include_once(ABSPATH . 'wp-admin/includes/plugin.php');
+}
 
 /**
  * Register batch handlers

--- a/plugins/quant/readme.txt
+++ b/plugins/quant/readme.txt
@@ -3,9 +3,9 @@ Contributors: stooit
 Donate link: https://www.quantcdn.io/
 Tags: static, jamstack, cdn, quant, static site generator
 Requires at least: 4.6
-Tested up to: 6.0
+Tested up to: 6.1.1
 Requires PHP: 7.1
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -64,6 +64,10 @@ Follow the [Forms documentation](https://docs.quantcdn.io/docs/dashboard/forms) 
 == Screenshots ==
 
 == Changelog ==
+
+= 1.4.2 =
+* Feature: Improved support for redirection plugin (add/update/delete tracking).
+* Tested with WordPress 6.1.1.
 
 = 1.4.1 =
 * Feature: Added timestamp_published value to search.

--- a/plugins/quant/src/Client.php
+++ b/plugins/quant/src/Client.php
@@ -51,6 +51,11 @@ class Client
         return TRUE;
     }
 
+    /**
+     * Unpublishes a route.
+     *
+     * @param string $route
+     */
     public function unpublish($route) {
         $endpoint = $this->endpoint . '/unpublish';
         $headers = $this->headers;
@@ -81,6 +86,21 @@ class Client
     }
 
     public function redirect($from, $to, $code) {
+
+        // Strip trailing slashes from redirects.
+        // This ensures consistency with how content routes are managed.
+        if ( strlen( $from ) > 1 ) {
+            $from = rtrim($from, '/');
+        }
+
+        if ( strlen( $to ) > 1 ) {
+            $to = rtrim($to, '/');
+        }
+
+        // Bail if either from or to is empty.
+        if (empty($from) || empty($to)) {
+          return;
+        }
 
         $data = [
             'url' => $from,
@@ -119,6 +139,11 @@ class Client
         // Strip trailing slashes from content routes (except home).
         if ( strlen( $data['url'] ) > 1 ) {
             $data['url'] = rtrim($data['url'], '/');
+        }
+
+        // Bail if the URL is empty.
+        if (empty($data['url'])) {
+          return;
         }
 
         $args = [

--- a/plugins/quant/src/functions.php
+++ b/plugins/quant/src/functions.php
@@ -6,6 +6,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     require_once(__DIR__.'/../quant-cli.php');
 }
 
+if (!function_exists('is_plugin_active')) {
+  include_once(ABSPATH . 'wp-admin/includes/plugin.php');
+}
+
 if ( is_plugin_active('redirection/redirection.php') ) {
     require_once(__DIR__.'/includes/redirection_functions.php');
 }

--- a/plugins/quant/src/functions.php
+++ b/plugins/quant/src/functions.php
@@ -6,6 +6,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     require_once(__DIR__.'/../quant-cli.php');
 }
 
+if ( is_plugin_active('redirection/redirection.php') ) {
+    require_once(__DIR__.'/includes/redirection_functions.php');
+}
+
 if (!empty($_SERVER['HTTP_QUANT_TOKEN'])) {
 
     $token = get_option('quant_internal_token');
@@ -296,6 +300,12 @@ if (!function_exists('quant_init_hooks')) {
 
         // Initialise unpublish/trash category hook.
         add_action('delete_category', 'quant_delete_category', 1000);
+
+        // Initialise redirection hooks (if plugin is active).
+        if ( is_plugin_active('redirection/redirection.php') ) {
+          add_action('redirection_redirect_updated', 'quant_redirection_redirect_updated', 1000);
+          add_action('redirection_redirect_deleted', 'quant_redirection_redirect_deleted', 1000);
+        }
     }
 
     // Init cron.

--- a/plugins/quant/src/includes/redirection_functions.php
+++ b/plugins/quant/src/includes/redirection_functions.php
@@ -1,0 +1,110 @@
+<?php
+
+use Quant\Client;
+
+if (!function_exists('quant_redirect_should_process')) {
+
+  /**
+   * Check whether this is a redirect we can action.
+   *
+   * @param Red_Item $redirect
+   * @return void
+   */
+  function quant_redirect_should_process($redirect)
+  {
+    if ($redirect->is_regex()) {
+      return FALSE;
+    }
+
+    // We only support URL matches.
+    if ($redirect->get_match_type() != 'url') {
+      return FALSE;
+    }
+
+    // We only support URL redirects.
+    if ($redirect->get_action_type() != 'url') {
+      return FALSE;
+    }
+
+    // We only support enabled URL redirects.
+    if (!$redirect->is_enabled()) {
+      return FALSE;
+    }
+
+    // If the action is not a string we cannot process.
+    if (!is_string($redirect->get_action_data())) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+}
+
+if (!function_exists('quant_redirection_redirect_updated')) {
+    /**
+     * Post updated redirect when updated.
+     *
+     * @param Red_Item $redirect
+     * @return void
+     */
+    function quant_redirection_redirect_updated($redirect)
+    {
+
+      // New redirects will be the inserted ID.
+      $is_new = is_int($redirect);
+
+      if (!$is_new) {
+        // This is the previous redirect.
+        // @todo: Delete/unpublish if relevant.
+        $old_redirect = $redirect;
+
+        // Once we flush we can load the updated values.
+        Red_Module::flush( $redirect->get_group_id() );
+
+        // Reload the redirect.
+        $redirect = Red_Item::get_by_id( $redirect->get_id() );
+        if ( !$redirect ) {
+          return;
+        }
+      }
+      else {
+        $redirect = Red_Item::get_by_id( $redirect );
+      }
+
+      if (!quant_redirect_should_process($redirect)) {
+        return;
+      }
+
+      $code = $redirect->get_action_code() == '301' ? 301 : 302;
+      $source = $redirect->get_url();
+      $dest = $redirect->get_action_data();
+
+      $client = new Client();
+      $client->redirect($source, $dest, $code);
+    }
+
+}
+
+
+
+
+if (!function_exists('quant_redirection_redirect_deleted')) {
+  /**
+   * Remove redirect from Quant when redirect is deleted.
+   *
+   * @param Red_Item $redirect
+   * @return void
+   */
+  function quant_redirection_redirect_deleted($redirect)
+  {
+
+    if (!quant_redirect_should_process($redirect)) {
+      return;
+    }
+
+    $client = new Client();
+    $client->unpublish($redirect->get_url());
+
+  }
+}

--- a/plugins/quant/src/includes/redirection_functions.php
+++ b/plugins/quant/src/includes/redirection_functions.php
@@ -86,9 +86,6 @@ if (!function_exists('quant_redirection_redirect_updated')) {
 
 }
 
-
-
-
 if (!function_exists('quant_redirection_redirect_deleted')) {
   /**
    * Remove redirect from Quant when redirect is deleted.


### PR DESCRIPTION
Improves the `redirection` plugin support by automatically adding, updating and unpublishing redirects as they are maintained in WordPress.

This also standardises redirect from/to routes to strip trailing slashes so it is consistent with how content routes are treated.

When the redirection monitoring mode is enabled (e.g WordPress creates redirects when a post route changes) this change will equally be reflected in Quant.